### PR TITLE
Set up netlify badge in readme to show deployment status #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # prime-number-checker
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/57f69f04-5ebc-4823-b950-5600b49ac985/deploy-status)](https://app.netlify.com/sites/prismatic-manatee-98d854/deploys)


### PR DESCRIPTION
Added line to README to set up a netlify badge that will display the status of the latest deploy